### PR TITLE
Add missing dependencies and disable ChaosMonkey by default

### DIFF
--- a/configurations/dla.yaml
+++ b/configurations/dla.yaml
@@ -3,7 +3,7 @@ components:
                 - DLA()
 #                - SaveImage()
                 - BoundingBox()
-                - ChaosMonkey()
+#                - ChaosMonkey()
 configuration:
         simulation_parameters:
                 year_start: 2000

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(name='vivarium_dla',
           'pandas',
           'numpy',
           'scipy',
+          'matplotlib',
+          'sklearn',
       ],
       )
 


### PR DESCRIPTION
The dependency on vivarium itself still isn't in there but that'll have to wait till we're up on pypi